### PR TITLE
Permissions - WIP

### DIFF
--- a/AppController.coffee
+++ b/AppController.coffee
@@ -396,29 +396,6 @@ class IDEAppController extends AppController
       @expandSidebar()  if @isSidebarCollapsed
 
 
-    # TODO: This will reactivated after release.
-    # temporary fix. ~Umut
-
-    # splitView.once 'PanelSetToFloating', =>
-    #   floatedPanel._lastSize = desiredSize
-    #   @getView().setClass 'sidebar-collapsed'
-    #   @isSidebarCollapsed = yes
-    #   KD.getSingleton("windowController").notifyWindowResizeListeners()
-
-    # # splitView.setFloatingPanel 0, 39
-    # tabView.showPaneByName 'Dummy'
-
-    # tabView.on 'PaneDidShow', (pane) ->
-    #   return if pane.options.name is 'Dummy'
-    #   splitView.showPanel 0
-    #   floatedPanel._lastSize = desiredSize
-
-    # floatedPanel.on 'ReceivedClickElsewhere', ->
-    #   KD.utils.defer ->
-    #     splitView.setFloatingPanel 0, 39
-    #     tabView.showPaneByName 'Dummy'
-
-
   expandSidebar: ->
 
     panel        = @workspace.getView()
@@ -431,13 +408,6 @@ class IDEAppController extends AppController
     floatedPanel.unsetClass 'floating'
     @isSidebarCollapsed = no
     filesPane.tabView.showPaneByName @activeFilesPaneName
-
-    # floatedPanel._lastSize = 250
-    # splitView.unsetFloatingPanel 0
-    # filesPane.tabView.showPaneByIndex 0
-    # floatedPanel.off 'ReceivedClickElsewhere'
-    # @getView().unsetClass 'sidebar-collapsed'
-    # @isSidebarCollapsed = no
 
 
   toggleSidebar: ->

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -1199,7 +1199,7 @@ class IDEAppController extends AppController
       {settingsPane} = @chat
 
       settingsPane.on 'ParticipantKicked', @bound 'handleParticipantKicked'
-      settingsPane.updatePermissions()
+      settingsPane.updateDefaultPermissions()
 
 
   createChatPane: ->

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -1770,7 +1770,7 @@ class IDEAppController extends AppController
     @isReadOnly = yes
     @forEachSubViewInIDEViews_ (pane) -> pane.makeReadOnly()
     @finderPane.makeReadOnly()
-    @getView.setClass 'read-only'
+    @getView().setClass 'read-only'
 
 
   makeEditable: ->
@@ -1780,4 +1780,4 @@ class IDEAppController extends AppController
     @isReadOnly = no
     @forEachSubViewInIDEViews_ (pane) -> pane.makeEditable()
     @finderPane.makeEditable()
-    @getView.unsetClass 'read-only'
+    @getView().unsetClass 'read-only'

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -1004,6 +1004,7 @@ class IDEAppController extends AppController
     @rtm.bindRealtimeListeners @changes, 'list'
     @rtm.bindRealtimeListeners @broadcastMessages, 'list'
     @rtm.bindRealtimeListeners @myWatchMap, 'map'
+    @rtm.bindRealtimeListeners @permissions, 'map'
 
     @rtm.on 'ValuesAddedToList', (list, event) =>
 

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -953,6 +953,8 @@ class IDEAppController extends AppController
 
       KD.utils.repeat 60 * 55 * 1000, => @rtm.reauth()
 
+      @finderPane.on 'ChangeHappened', @bound 'syncChange'
+
 
   setCollaborativeReferences: ->
 

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -1021,6 +1021,7 @@ class IDEAppController extends AppController
     @rtm.on 'MapValueChanged', (map, event) =>
 
       if      map is @myWatchMap  then @handleWatchMapChange event
+      else if map is @permissions then @handlePermissionsMapChange event
 
 
   handleWatchMapChange: (event) ->
@@ -1033,6 +1034,10 @@ class IDEAppController extends AppController
     else unless newValue
       @statusBar.emit 'ParticipantUnwatched', property
 
+
+  handlePermissionsMapChange: (event) ->
+
+    @chat.settingsPane.defaultPermission.setValue event.newValue
 
 
   handleChange: (change) ->

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -1181,7 +1181,10 @@ class IDEAppController extends AppController
 
       @statusBar.emit 'CollaborationStarted'
 
-      @chat.settingsPane.on 'ParticipantKicked', @bound 'handleParticipantKicked'
+      {settingsPane} = @chat
+
+      settingsPane.on 'ParticipantKicked', @bound 'handleParticipantKicked'
+      settingsPane.updatePermissions()
 
 
   createChatPane: ->

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -863,6 +863,9 @@ class IDEAppController extends AppController
 
       @finderPane.on 'ChangeHappened', @bound 'syncChange'
 
+      unless @amIHost
+        @makeReadOnly()  if @permissions.get(nickname) is 'read'
+
 
   setCollaborativeReferences: ->
 

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -1768,6 +1768,7 @@ class IDEAppController extends AppController
     return  if @isReadOnly
 
     @isReadOnly = yes
+    ideView.isReadOnly = yes  for ideView in @ideViews
     @forEachSubViewInIDEViews_ (pane) -> pane.makeReadOnly()
     @finderPane.makeReadOnly()
     @getView().setClass 'read-only'
@@ -1778,6 +1779,7 @@ class IDEAppController extends AppController
     return  unless @isReadOnly
 
     @isReadOnly = no
+    ideView.isReadOnly = no  for ideView in @ideViews
     @forEachSubViewInIDEViews_ (pane) -> pane.makeEditable()
     @finderPane.makeEditable()
     @getView().unsetClass 'read-only'

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -1020,8 +1020,11 @@ class IDEAppController extends AppController
 
     @rtm.on 'MapValueChanged', (map, event) =>
 
-      if      map is @myWatchMap  then @handleWatchMapChange event
-      else if map is @permissions then @handlePermissionsMapChange event
+      if map is @myWatchMap
+        @handleWatchMapChange event
+
+      else if map is @permissions
+        @chat.settingsPane.emit 'PermissionChanged', event
 
 
   handleWatchMapChange: (event) ->
@@ -1033,11 +1036,6 @@ class IDEAppController extends AppController
 
     else unless newValue
       @statusBar.emit 'ParticipantUnwatched', property
-
-
-  handlePermissionsMapChange: (event) ->
-
-    @chat.settingsPane.defaultPermission.setValue event.newValue
 
 
   handleChange: (change) ->

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -906,25 +906,12 @@ class IDEAppController extends AppController
     @rtm.getFile fileId
 
     @rtm.once 'FileLoaded', (doc) =>
+      nickname = KD.nick()
+      hostName = @collaborationHost
+
       @rtm.setRealtimeDoc doc
-      nickname           = KD.nick()
-      myWatchMapName     = "#{nickname}WatchMap"
-      mySnapshotName     = "#{nickname}Snapshot"
-      hostName           = @collaborationHost
 
-      @participants      = @rtm.getFromModel 'participants'
-      @changes           = @rtm.getFromModel 'changes'
-      @broadcastMessages = @rtm.getFromModel 'broadcastMessages'
-      @pingTime          = @rtm.getFromModel 'pingTime'
-      @myWatchMap        = @rtm.getFromModel myWatchMapName
-      @mySnapshot        = @rtm.getFromModel mySnapshotName
-
-      @participants      or= @rtm.create 'list',   'participants', []
-      @changes           or= @rtm.create 'list',   'changes', []
-      @broadcastMessages or= @rtm.create 'list',   'broadcastMessages', []
-      @pingTime          or= @rtm.create 'string', 'pingTime'
-      @myWatchMap        or= @rtm.create 'map',    myWatchMapName, {}
-      @mySnapshot        or= @rtm.create 'map',    mySnapshotName, @getWorkspaceSnapshot()
+      @setCollaborativeReferences()
 
       if @amIHost
         @getView().setClass 'host'
@@ -965,6 +952,27 @@ class IDEAppController extends AppController
           @createPaneFromChange change
 
       KD.utils.repeat 60 * 55 * 1000, => @rtm.reauth()
+
+
+  setCollaborativeReferences: ->
+
+    nickname           = KD.nick()
+    myWatchMapName     = "#{nickname}WatchMap"
+    mySnapshotName     = "#{nickname}Snapshot"
+
+    @participants      = @rtm.getFromModel 'participants'
+    @changes           = @rtm.getFromModel 'changes'
+    @broadcastMessages = @rtm.getFromModel 'broadcastMessages'
+    @pingTime          = @rtm.getFromModel 'pingTime'
+    @myWatchMap        = @rtm.getFromModel myWatchMapName
+    @mySnapshot        = @rtm.getFromModel mySnapshotName
+
+    @participants      or= @rtm.create 'list',   'participants', []
+    @changes           or= @rtm.create 'list',   'changes', []
+    @broadcastMessages or= @rtm.create 'list',   'broadcastMessages', []
+    @pingTime          or= @rtm.create 'string', 'pingTime'
+    @myWatchMap        or= @rtm.create 'map',    myWatchMapName, {}
+    @mySnapshot        or= @rtm.create 'map',    mySnapshotName, @getWorkspaceSnapshot()
 
 
   registerCollaborationSessionId: ->

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -1761,3 +1761,23 @@ class IDEAppController extends AppController
                 title    : "@#{@collaborationHost} has left the session."
                 duration : 3000
               KD.singletons.router.handleRoute '/IDE'
+
+
+  makeReadOnly: ->
+
+    return  if @isReadOnly
+
+    @isReadOnly = yes
+    @forEachSubViewInIDEViews_ (pane) -> pane.makeReadOnly()
+    @finderPane.makeReadOnly()
+    @getView.setClass 'read-only'
+
+
+  makeEditable: ->
+
+    return  unless @isReadOnly
+
+    @isReadOnly = no
+    @forEachSubViewInIDEViews_ (pane) -> pane.makeEditable()
+    @finderPane.makeEditable()
+    @getView.unsetClass 'read-only'

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -6,70 +6,7 @@ class IDEAppController extends AppController
   } = Machine.State
 
 
-  KD.registerAppClass this,
-    name         : 'IDE'
-    behavior     : 'application'
-    multiple     : yes
-    preCondition :
-      condition  : (options, cb) -> cb KD.isLoggedIn()
-      failure    : (options, cb) ->
-        KD.getSingleton('appManager').open 'IDE', conditionPassed : yes
-        KD.showEnforceLoginModal()
-    commands:
-      'find file by name'   : 'showFileFinder'
-      'search all files'    : 'showContentSearch'
-      'split vertically'    : 'splitVertically'
-      'split horizontally'  : 'splitHorizontally'
-      'merge splitview'     : 'mergeSplitView'
-      'preview file'        : 'previewFile'
-      'save all files'      : 'saveAllFiles'
-      'create new file'     : 'createNewFile'
-      'create new terminal' : 'createNewTerminal'
-      'create new drawing'  : 'createNewDrawing'
-      'collapse sidebar'    : 'collapseSidebar'
-      'expand sidebar'      : 'expandSidebar'
-      'toggle sidebar'      : 'toggleSidebar'
-      'close tab'           : 'closeTab'
-      'go to left tab'      : 'goToLeftTab'
-      'go to right tab'     : 'goToRightTab'
-      'go to tab number'    : 'goToTabNumber'
-      'fullscren ideview'   : 'toggleFullscreenIDEView'
-      'move tab up'         : 'moveTabUp'
-      'move tab down'       : 'moveTabDown'
-      'move tab left'       : 'moveTabLeft'
-      'move tab right'      : 'moveTabRight'
-
-    keyBindings: [
-      { command: 'find file by name',   binding: 'ctrl+alt+o',           global: yes }
-      { command: 'search all files',    binding: 'ctrl+alt+f',           global: yes }
-      { command: 'split vertically',    binding: 'ctrl+alt+v',           global: yes }
-      { command: 'split horizontally',  binding: 'ctrl+alt+h',           global: yes }
-      { command: 'merge splitview',     binding: 'ctrl+alt+m',           global: yes }
-      { command: 'preview file',        binding: 'ctrl+alt+p',           global: yes }
-      { command: 'save all files',      binding: 'ctrl+alt+s',           global: yes }
-      { command: 'create new file',     binding: 'ctrl+alt+n',           global: yes }
-      { command: 'create new terminal', binding: 'ctrl+alt+t',           global: yes }
-      { command: 'create new browser',  binding: 'ctrl+alt+b',           global: yes }
-      { command: 'create new drawing',  binding: 'ctrl+alt+d',           global: yes }
-      { command: 'toggle sidebar',      binding: 'ctrl+alt+k',           global: yes }
-      { command: 'close tab',           binding: 'ctrl+alt+w',           global: yes }
-      { command: 'go to left tab',      binding: 'ctrl+alt+[',           global: yes }
-      { command: 'go to right tab',     binding: 'ctrl+alt+]',           global: yes }
-      { command: 'go to tab number',    binding: 'mod+1',                global: yes }
-      { command: 'go to tab number',    binding: 'mod+2',                global: yes }
-      { command: 'go to tab number',    binding: 'mod+3',                global: yes }
-      { command: 'go to tab number',    binding: 'mod+4',                global: yes }
-      { command: 'go to tab number',    binding: 'mod+5',                global: yes }
-      { command: 'go to tab number',    binding: 'mod+6',                global: yes }
-      { command: 'go to tab number',    binding: 'mod+7',                global: yes }
-      { command: 'go to tab number',    binding: 'mod+8',                global: yes }
-      { command: 'go to tab number',    binding: 'mod+9',                global: yes }
-      { command: 'fullscren ideview',   binding: 'mod+shift+enter',      global: yes }
-      { command: 'move tab up',         binding: 'mod+alt+shift+up',     global: yes }
-      { command: 'move tab down',       binding: 'mod+alt+shift+down',   global: yes }
-      { command: 'move tab left',       binding: 'mod+alt+shift+left',   global: yes }
-      { command: 'move tab right',      binding: 'mod+alt+shift+right',  global: yes }
-    ]
+  KD.registerAppClass this, new IDE.AppControllerOptions
 
   constructor: (options = {}, data) ->
     options.appInfo =

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -465,6 +465,7 @@ class IDEAppController extends AppController
     @activeTabView.emit 'DrawingPaneRequested', paneHash
 
   moveTab: (direction) ->
+
     return unless @activeTabView.parent?
 
     panel = @activeTabView.parent.parent
@@ -868,9 +869,11 @@ class IDEAppController extends AppController
     nickname           = KD.nick()
     myWatchMapName     = "#{nickname}WatchMap"
     mySnapshotName     = "#{nickname}Snapshot"
+    defaultPermission  = default: 'edit'
 
     @participants      = @rtm.getFromModel 'participants'
     @changes           = @rtm.getFromModel 'changes'
+    @permissions       = @rtm.getFromModel 'permissions'
     @broadcastMessages = @rtm.getFromModel 'broadcastMessages'
     @pingTime          = @rtm.getFromModel 'pingTime'
     @myWatchMap        = @rtm.getFromModel myWatchMapName
@@ -878,6 +881,7 @@ class IDEAppController extends AppController
 
     @participants      or= @rtm.create 'list',   'participants', []
     @changes           or= @rtm.create 'list',   'changes', []
+    @permissions       or= @rtm.create 'map',    'permissions', defaultPermission
     @broadcastMessages or= @rtm.create 'list',   'broadcastMessages', []
     @pingTime          or= @rtm.create 'string', 'pingTime'
     @myWatchMap        or= @rtm.create 'map',    myWatchMapName, {}

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -1157,6 +1157,8 @@ class IDEAppController extends AppController
 
     return unless change.context
 
+    return @finderPane  if change.type is 'FileTreeInteraction'
+
     targetPane = null
     {context}  = change
     {paneType} = context
@@ -1249,6 +1251,7 @@ class IDEAppController extends AppController
 
 
   getWorkspaceName: (callback) -> callback @workspaceData.name
+
 
   createChatPaneView: (channel) ->
 

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -1020,15 +1020,19 @@ class IDEAppController extends AppController
 
     @rtm.on 'MapValueChanged', (map, event) =>
 
-      return unless map is @myWatchMap
+      if      map is @myWatchMap  then @handleWatchMapChange event
 
-      {property, newValue, oldValue} = event
 
-      if newValue is property
-        @statusBar.emit 'ParticipantWatched', property
+  handleWatchMapChange: (event) ->
 
-      else unless newValue
-        @statusBar.emit 'ParticipantUnwatched', property
+    {property, newValue, oldValue} = event
+
+    if newValue is property
+      @statusBar.emit 'ParticipantWatched', property
+
+    else unless newValue
+      @statusBar.emit 'ParticipantUnwatched', property
+
 
 
   handleChange: (change) ->

--- a/AppController.coffee
+++ b/AppController.coffee
@@ -1024,7 +1024,19 @@ class IDEAppController extends AppController
         @handleWatchMapChange event
 
       else if map is @permissions
-        @chat.settingsPane.emit 'PermissionChanged', event
+        @handlePermissionMapChange event
+
+
+  handlePermissionMapChange: (event) ->
+
+    @chat.settingsPane.emit 'PermissionChanged', event
+
+    {property, newValue} = event
+
+    return  unless property is KD.nick()
+
+    if      newValue is 'edit' then @makeEditable()
+    else if newValue is 'read' then @makeReadOnly()
 
 
   handleWatchMapChange: (event) ->

--- a/AppControllerOptions.coffee
+++ b/AppControllerOptions.coffee
@@ -1,0 +1,65 @@
+class IDE.AppControllerOptions
+
+  name        : 'IDE'
+  behavior    : 'application'
+  multiple    : yes
+  preCondition:
+    condition  : (options, cb) -> cb KD.isLoggedIn()
+    failure    : (options, cb) ->
+      KD.getSingleton('appManager').open 'IDE', conditionPassed : yes
+      KD.showEnforceLoginModal()
+  commands:
+    'find file by name'   : 'showFileFinder'
+    'search all files'    : 'showContentSearch'
+    'split vertically'    : 'splitVertically'
+    'split horizontally'  : 'splitHorizontally'
+    'merge splitview'     : 'mergeSplitView'
+    'preview file'        : 'previewFile'
+    'save all files'      : 'saveAllFiles'
+    'create new file'     : 'createNewFile'
+    'create new terminal' : 'createNewTerminal'
+    'create new drawing'  : 'createNewDrawing'
+    'collapse sidebar'    : 'collapseSidebar'
+    'expand sidebar'      : 'expandSidebar'
+    'toggle sidebar'      : 'toggleSidebar'
+    'close tab'           : 'closeTab'
+    'go to left tab'      : 'goToLeftTab'
+    'go to right tab'     : 'goToRightTab'
+    'go to tab number'    : 'goToTabNumber'
+    'fullscren ideview'   : 'toggleFullscreenIDEView'
+    'move tab up'         : 'moveTabUp'
+    'move tab down'       : 'moveTabDown'
+    'move tab left'       : 'moveTabLeft'
+    'move tab right'      : 'moveTabRight'
+
+  keyBindings: [
+    { command: 'find file by name',   binding: 'ctrl+alt+o',           global: yes }
+    { command: 'search all files',    binding: 'ctrl+alt+f',           global: yes }
+    { command: 'split vertically',    binding: 'ctrl+alt+v',           global: yes }
+    { command: 'split horizontally',  binding: 'ctrl+alt+h',           global: yes }
+    { command: 'merge splitview',     binding: 'ctrl+alt+m',           global: yes }
+    { command: 'preview file',        binding: 'ctrl+alt+p',           global: yes }
+    { command: 'save all files',      binding: 'ctrl+alt+s',           global: yes }
+    { command: 'create new file',     binding: 'ctrl+alt+n',           global: yes }
+    { command: 'create new terminal', binding: 'ctrl+alt+t',           global: yes }
+    { command: 'create new browser',  binding: 'ctrl+alt+b',           global: yes }
+    { command: 'create new drawing',  binding: 'ctrl+alt+d',           global: yes }
+    { command: 'toggle sidebar',      binding: 'ctrl+alt+k',           global: yes }
+    { command: 'close tab',           binding: 'ctrl+alt+w',           global: yes }
+    { command: 'go to left tab',      binding: 'ctrl+alt+[',           global: yes }
+    { command: 'go to right tab',     binding: 'ctrl+alt+]',           global: yes }
+    { command: 'go to tab number',    binding: 'mod+1',                global: yes }
+    { command: 'go to tab number',    binding: 'mod+2',                global: yes }
+    { command: 'go to tab number',    binding: 'mod+3',                global: yes }
+    { command: 'go to tab number',    binding: 'mod+4',                global: yes }
+    { command: 'go to tab number',    binding: 'mod+5',                global: yes }
+    { command: 'go to tab number',    binding: 'mod+6',                global: yes }
+    { command: 'go to tab number',    binding: 'mod+7',                global: yes }
+    { command: 'go to tab number',    binding: 'mod+8',                global: yes }
+    { command: 'go to tab number',    binding: 'mod+9',                global: yes }
+    { command: 'fullscren ideview',   binding: 'mod+shift+enter',      global: yes }
+    { command: 'move tab up',         binding: 'mod+alt+shift+up',     global: yes }
+    { command: 'move tab down',       binding: 'mod+alt+shift+down',   global: yes }
+    { command: 'move tab left',       binding: 'mod+alt+shift+left',   global: yes }
+    { command: 'move tab right',      binding: 'mod+alt+shift+right',  global: yes }
+  ]

--- a/finder/idefindertreecontroller.coffee
+++ b/finder/idefindertreecontroller.coffee
@@ -31,6 +31,8 @@ class IDE.FinderTreeController extends NFinderTreeController
 
     super nodeView, callback
 
+    return  if @dontEmitChangeEvent
+
     @emit 'FolderCollapsed', nodeView.getData().path
 
 
@@ -38,5 +40,6 @@ class IDE.FinderTreeController extends NFinderTreeController
 
     super nodeView, callback
 
+    return  if @dontEmitChangeEvent
 
     @emit 'FolderExpanded', nodeView.getData().path

--- a/finder/idefindertreecontroller.coffee
+++ b/finder/idefindertreecontroller.coffee
@@ -25,3 +25,22 @@ class IDE.FinderTreeController extends NFinderTreeController
     path            = FSHelper.plainPath path
 
     appManager.tell 'IDE', 'createNewTerminal', { machine, path }
+
+
+  collapseFolder: (nodeView, callback) ->
+
+    super nodeView, callback
+
+    @emit 'FolderCollapsed', @getFolderPath_ nodeView
+
+
+  expandFolder: (nodeView, callback) ->
+
+    super nodeView, callback
+
+    @emit 'FolderExpanded', @getFolderPath_ nodeView
+
+
+  getFolderPath_: (nodeView) ->
+
+    return FSHelper.plainPath nodeView.getData().path

--- a/finder/idefindertreecontroller.coffee
+++ b/finder/idefindertreecontroller.coffee
@@ -31,16 +31,12 @@ class IDE.FinderTreeController extends NFinderTreeController
 
     super nodeView, callback
 
-    @emit 'FolderCollapsed', @getFolderPath_ nodeView
+    @emit 'FolderCollapsed', nodeView.getData().path
 
 
   expandFolder: (nodeView, callback) ->
 
     super nodeView, callback
 
-    @emit 'FolderExpanded', @getFolderPath_ nodeView
 
-
-  getFolderPath_: (nodeView) ->
-
-    return FSHelper.plainPath nodeView.getData().path
+    @emit 'FolderExpanded', nodeView.getData().path

--- a/includes.coffee
+++ b/includes.coffee
@@ -3,9 +3,6 @@ module.exports = [
   # namespacing
   "namespaces.coffee"
 
-  # ndpane 0.1.2
-  "../../website/a/js/ndpane.min.js"
-
   # finder
   "finder/idefindercontextmenucontroller.coffee"
   "finder/idefindertreecontroller.coffee"
@@ -76,6 +73,7 @@ module.exports = [
   # 3rd party
   "../../website/a/js/sketchpad.js"
   "../../website/a/js/gapi.js"
+  "../../website/a/js/ndpane.min.js"
 
   # collaboration
   "RealTimeManager.coffee"

--- a/includes.coffee
+++ b/includes.coffee
@@ -65,6 +65,7 @@ module.exports = [
   # misc views
   "views/basesplitview.coffee"
 
+  "AppControllerOptions.coffee"
   "AppController.coffee"
 
   # stylus

--- a/styl/ide.styl
+++ b/styl/ide.styl
@@ -924,11 +924,10 @@ body.ide .kddialogview.save-as-dialog
 
 .ide .application-page.read-only
   .kdtabhandle.plus
+  .nfinder .chevron
+  .kdtabhandle .close-tab
+  .kdtabhandle .options
     hidden()
 
-  .nfinder
-    .chevron
-      hidden()
-
-    ul ul li.selected
-      bg                    color, transparent
+  ul ul li.selected
+    bg                    color, transparent

--- a/styl/ide.styl
+++ b/styl/ide.styl
@@ -930,4 +930,7 @@ body.ide .kddialogview.save-as-dialog
     hidden()
 
   ul ul li.selected
-    bg                    color, transparent
+    bg                      color, transparent
+
+  .kdtabhandle
+    pointer-events          none

--- a/styl/ide.styl
+++ b/styl/ide.styl
@@ -920,3 +920,15 @@ body.ide .kddialogview.save-as-dialog
       r-sprite              ide help
       margin-top            -6px
       display               block
+
+
+.ide .application-page.read-only
+  .kdtabhandle.plus
+    hidden()
+
+  .nfinder
+    .chevron
+      hidden()
+
+    ul ul li.selected
+      bg                    color, transparent

--- a/views/chat/chatparticipantview.coffee
+++ b/views/chat/chatparticipantview.coffee
@@ -50,7 +50,7 @@ class IDE.ChatParticipantView extends JView
     @settings       = new KDSelectBox
       defaultValue  : 'edit'
       selectOptions : [
-        # { title : 'CAN READ', value : 'read'}
+        { title : 'CAN READ', value : 'read'}
         { title : 'CAN EDIT', value : 'edit'}
       ]
 

--- a/views/chat/chatparticipantview.coffee
+++ b/views/chat/chatparticipantview.coffee
@@ -6,16 +6,16 @@ class IDE.ChatParticipantView extends JView
 
     super options, data
 
-    {@isInSession} = options
-
     @createElements()
 
 
   createElements: ->
 
-    { isOnline, @isWatching } = @getOptions()
-    { account, channel }      = @getData()
-    { nickname }              = account.profile
+    { isOnline, @isWatching, @isInSession } = @getOptions()
+    { account, channel } = @getData()
+    { nickname }         = account.profile
+
+    @amIHost = not @isInSession
 
     if isOnline then @setClass 'online' else @setClass 'offline'
 
@@ -29,7 +29,7 @@ class IDE.ChatParticipantView extends JView
 
     @kickButton = new KDCustomHTMLView cssClass: 'hidden'
 
-    unless @isInSession
+    if @amIHost
       @kickButton  = new KDButtonView
         title    : 'KICK'
         cssClass : 'kick-button'

--- a/views/chat/chatparticipantview.coffee
+++ b/views/chat/chatparticipantview.coffee
@@ -52,6 +52,8 @@ class IDE.ChatParticipantView extends JView
     @permissions    = new KDSelectBox
       defaultValue  : permission
       disabled      : not @amIHost
+      callback      : (permission) =>
+        @emit 'ParticipantPermissionChanged', permission
       selectOptions : [
         { title : 'CAN READ', value : 'read'}
         { title : 'CAN EDIT', value : 'edit'}

--- a/views/chat/chatparticipantview.coffee
+++ b/views/chat/chatparticipantview.coffee
@@ -38,6 +38,8 @@ class IDE.ChatParticipantView extends JView
     @watchButton = new KDButtonView
       iconOnly : 'yes'
       cssClass : 'watch-button'
+      tooltip  :
+        title  : "Watch #{nickname}"
       callback : =>
         methodName  = if @isWatching then 'unwatchParticipant' else 'watchParticipant'
         @isWatching = not @isWatching

--- a/views/chat/chatparticipantview.coffee
+++ b/views/chat/chatparticipantview.coffee
@@ -11,7 +11,7 @@ class IDE.ChatParticipantView extends JView
 
   createElements: ->
 
-    { isOnline, @isWatching, @isInSession } = @getOptions()
+    { isOnline, @isWatching, @isInSession, permission } = @getOptions()
     { account, channel } = @getData()
     { nickname }         = account.profile
 
@@ -49,8 +49,8 @@ class IDE.ChatParticipantView extends JView
 
     @watchButton.setClass 'watching'  if @isWatching
 
-      defaultValue  : 'edit'
     @permissions    = new KDSelectBox
+      defaultValue  : permission
       disabled      : not @amIHost
       selectOptions : [
         { title : 'CAN READ', value : 'read'}

--- a/views/chat/chatparticipantview.coffee
+++ b/views/chat/chatparticipantview.coffee
@@ -49,6 +49,7 @@ class IDE.ChatParticipantView extends JView
 
     @settings       = new KDSelectBox
       defaultValue  : 'edit'
+      disabled      : not @amIHost
       selectOptions : [
         { title : 'CAN READ', value : 'read'}
         { title : 'CAN EDIT', value : 'edit'}

--- a/views/chat/chatparticipantview.coffee
+++ b/views/chat/chatparticipantview.coffee
@@ -49,8 +49,8 @@ class IDE.ChatParticipantView extends JView
 
     @watchButton.setClass 'watching'  if @isWatching
 
-    @settings       = new KDSelectBox
       defaultValue  : 'edit'
+    @permissions    = new KDSelectBox
       disabled      : not @amIHost
       selectOptions : [
         { title : 'CAN READ', value : 'read'}
@@ -76,6 +76,6 @@ class IDE.ChatParticipantView extends JView
       <div class="settings">
         {{> @kickButton}}
         {{> @watchButton}}
-        {{> @settings}}
+        {{> @permissions}}
       <div>
     """

--- a/views/chat/chatview.coffee
+++ b/views/chat/chatview.coffee
@@ -109,9 +109,9 @@ class IDE.ChatView extends KDTabView
 
 
   showSettingsPane: -> @showPane @settingsPane
-  
-  
+
+
   sessionStarted: ->
-    
+
     @showChatPane()
     @chatPane.refresh()

--- a/views/chat/messagepane.coffee
+++ b/views/chat/messagepane.coffee
@@ -101,9 +101,9 @@ class IDE.ChatMessagePane extends PrivateMessagePane
       cssClass   : 'workspace-name'
       partial    : 'My Workspace'
       attributes : href : '#'
-      click      : (event) =>
-        KD.utils.stopDOMEvent event
-        @getDelegate().showSettingsPane()
+      # click      : (event) =>
+      #   KD.utils.stopDOMEvent event
+      #   @getDelegate().showSettingsPane()
 
     appManager.tell 'IDE', 'getWorkspaceName', @title.bound 'updatePartial'
 
@@ -136,7 +136,7 @@ class IDE.ChatMessagePane extends PrivateMessagePane
 
     menu =
       'Search'     : cssClass : 'disabled', callback: noop
-      'Settings'   : callback : @getDelegate().bound 'showSettingsPane'
+      # 'Settings'   : callback : @getDelegate().bound 'showSettingsPane'
       'Minimize'   : callback : @getDelegate().bound 'end'
       'Learn More' : separator: yes, callback : -> KD.utils.createExternalLink 'http://learn.koding.com/collaboration'
 

--- a/views/chat/messagepane.coffee
+++ b/views/chat/messagepane.coffee
@@ -101,9 +101,9 @@ class IDE.ChatMessagePane extends PrivateMessagePane
       cssClass   : 'workspace-name'
       partial    : 'My Workspace'
       attributes : href : '#'
-      # click      : (event) =>
-      #   KD.utils.stopDOMEvent event
-      #   @getDelegate().showSettingsPane()
+      click      : (event) =>
+        KD.utils.stopDOMEvent event
+        @getDelegate().showSettingsPane()
 
     appManager.tell 'IDE', 'getWorkspaceName', @title.bound 'updatePartial'
 
@@ -135,10 +135,10 @@ class IDE.ChatMessagePane extends PrivateMessagePane
   settingsMenu: ->
 
     menu =
-      'Search'        : cssClass : 'disabled', callback: noop
-      # 'Settings'    : callback : @getDelegate().bound 'showSettingsPane'
-      'Minimize'      : callback : @getDelegate().bound 'end'
-      'Learn More'    : separator: yes, callback : -> KD.utils.createExternalLink 'http://learn.koding.com/collaboration'
+      'Search'     : cssClass : 'disabled', callback: noop
+      'Settings'   : callback : @getDelegate().bound 'showSettingsPane'
+      'Minimize'   : callback : @getDelegate().bound 'end'
+      'Learn More' : separator: yes, callback : -> KD.utils.createExternalLink 'http://learn.koding.com/collaboration'
 
     if @isInSession
     then menu['Leave Session'] = { callback : => @parent.settingsPane.leaveSession() }

--- a/views/chat/messagepane.coffee
+++ b/views/chat/messagepane.coffee
@@ -168,11 +168,11 @@ class IDE.ChatMessagePane extends PrivateMessagePane
     appManager = KD.getSingleton 'appManager'
     appManager.tell 'IDE', 'setMachineUser', [participant]
 
-  
+
   refresh: ->
-    
+
     return  if not @listController.getItemCount()
-    
+
     @resetPadding()
     item.checkIfItsTooTall()  for item in @listController.getListItems()
     @scrollView.wrapper.emit 'MutationHappened'

--- a/views/chat/settingspane.coffee
+++ b/views/chat/settingspane.coffee
@@ -70,6 +70,7 @@ class IDE.ChatSettingsPane extends KDTabPaneView
 
     @defaultPermission = new KDSelectBox
       defaultValue  : 'edit'
+      callback      : (value) => @setDefaultPermission value
       selectOptions : [
         { title : 'CAN READ', value : 'read'}
         { title : 'CAN EDIT', value : 'edit'}
@@ -203,6 +204,12 @@ class IDE.ChatSettingsPane extends KDTabPaneView
 
     KD.remote.cacheable nickname, (err, account) =>
       @createParticipantView account.first, yes
+
+
+
+  setDefaultPermission: (value) ->
+
+    @rtm.getFromModel('permissions').set 'default', value
 
 
   viewAppended: JView::viewAppended

--- a/views/chat/settingspane.coffee
+++ b/views/chat/settingspane.coffee
@@ -71,6 +71,7 @@ class IDE.ChatSettingsPane extends KDTabPaneView
     @defaultPermission = new KDSelectBox
       defaultValue  : 'edit'
       callback      : (value) => @setDefaultPermission value
+      disabled      : not @amIHost
       selectOptions : [
         { title : 'CAN READ', value : 'read'}
         { title : 'CAN EDIT', value : 'edit'}

--- a/views/chat/settingspane.coffee
+++ b/views/chat/settingspane.coffee
@@ -18,6 +18,7 @@ class IDE.ChatSettingsPane extends KDTabPaneView
     @on 'CollaborationNotInitialized', => @everyone.destroySubViews()
     @on 'ParticipantJoined', @bound 'addParticipant'
     @on 'ParticipantLeft',   @bound 'removeParticipant'
+    @on 'PermissionChanged', @bound 'handlePermissionChange'
 
     @on 'CollaborationEnded', =>
       @toggleButtons 'ended'
@@ -223,6 +224,17 @@ class IDE.ChatSettingsPane extends KDTabPaneView
   setDefaultPermission: (value) ->
 
     @rtm.getFromModel('permissions').set 'default', value
+
+
+  handlePermissionChange: (event) ->
+    {newValue, property} = event
+
+    return  unless newValue in ['edit', 'read']
+
+    if property is 'default'
+      @defaultPermission.setValue newValue
+    else
+      @participantViews[property]?.permissions.setValue newValue
 
 
   viewAppended: JView::viewAppended

--- a/views/chat/settingspane.coffee
+++ b/views/chat/settingspane.coffee
@@ -206,6 +206,12 @@ class IDE.ChatSettingsPane extends KDTabPaneView
       @createParticipantView account.first, yes
 
 
+  updatePermissions: ->
+
+    permissions = @rtm.getFromModel 'permissions'
+    @defaultPermission.setValue permissions.get 'default'
+
+
 
   setDefaultPermission: (value) ->
 

--- a/views/chat/settingspane.coffee
+++ b/views/chat/settingspane.coffee
@@ -71,7 +71,7 @@ class IDE.ChatSettingsPane extends KDTabPaneView
     @defaultSetting = new KDSelectBox
       defaultValue  : 'edit'
       selectOptions : [
-        # { title : 'CAN READ', value : 'read'}
+        { title : 'CAN READ', value : 'read'}
         { title : 'CAN EDIT', value : 'edit'}
       ]
 

--- a/views/chat/settingspane.coffee
+++ b/views/chat/settingspane.coffee
@@ -215,7 +215,7 @@ class IDE.ChatSettingsPane extends KDTabPaneView
       @createParticipantView account.first, yes
 
 
-  updatePermissions: ->
+  updateDefaultPermissions: ->
 
     permissions = @rtm.getFromModel 'permissions'
     @defaultPermission.setValue permissions.get 'default'
@@ -227,6 +227,7 @@ class IDE.ChatSettingsPane extends KDTabPaneView
 
 
   handlePermissionChange: (event) ->
+
     {newValue, property} = event
 
     return  unless newValue in ['edit', 'read']

--- a/views/chat/settingspane.coffee
+++ b/views/chat/settingspane.coffee
@@ -68,7 +68,7 @@ class IDE.ChatSettingsPane extends KDTabPaneView
       cssClass : 'chat-link'
       click    : => @getDelegate().showChatPane()
 
-    @defaultSetting = new KDSelectBox
+    @defaultPermission = new KDSelectBox
       defaultValue  : 'edit'
       selectOptions : [
         { title : 'CAN READ', value : 'read'}
@@ -217,7 +217,7 @@ class IDE.ChatSettingsPane extends KDTabPaneView
         {{> @back}}
       </header>
       <ul class='settings default'>
-        <li><label>Anyone who joins</label>{{> @defaultSetting}}</li>
+        <li><label>Anyone who joins</label>{{> @defaultPermission}}</li>
       </ul>
       {{> @everyone}}
       <div class="warning">

--- a/views/chat/settingspane.coffee
+++ b/views/chat/settingspane.coffee
@@ -191,6 +191,9 @@ class IDE.ChatSettingsPane extends KDTabPaneView
     @everyone.addSubView participantView, null, isOnline
     @onboarding?.destroy()
 
+    participantView.on 'ParticipantPermissionChanged', (permission) =>
+      @rtm.getFromModel('permissions').set nickname, permission
+
 
   removeParticipant: (username, unshare) ->
 

--- a/views/chat/settingspane.coffee
+++ b/views/chat/settingspane.coffee
@@ -176,15 +176,19 @@ class IDE.ChatSettingsPane extends KDTabPaneView
 
   createParticipantView: (account, isOnline) =>
 
-    {nickname} = account.profile
-    isWatching = @rtm.getFromModel("#{KD.nick()}WatchMap").keys().indexOf(nickname) > -1
-    channel    = @getData()
-    options    = { isOnline, @isInSession, isWatching }
-    data       = { account, channel }
-    view       = new IDE.ChatParticipantView options, data
+    {nickname}        = account.profile
+    watchList         = @rtm.getFromModel("#{KD.nick()}WatchMap").keys()
+    isWatching        = watchList.indexOf(nickname) > -1
+    permissionsMap    = @rtm.getFromModel 'permissions'
+    defaultPermission = permissionsMap.get 'default'
+    permission        = permissionsMap.get(nickname) or defaultPermission
+    channel           = @getData()
+    options           = { isOnline, @isInSession, isWatching, permission }
+    data              = { account, channel }
+    participantView   = new IDE.ChatParticipantView options, data
 
-    @participantViews[nickname] = view
-    @everyone.addSubView view, null, isOnline
+    @participantViews[nickname] = participantView
+    @everyone.addSubView participantView, null, isOnline
     @onboarding?.destroy()
 
 
@@ -211,7 +215,6 @@ class IDE.ChatSettingsPane extends KDTabPaneView
 
     permissions = @rtm.getFromModel 'permissions'
     @defaultPermission.setValue permissions.get 'default'
-
 
 
   setDefaultPermission: (value) ->

--- a/views/tabview/ideview.coffee
+++ b/views/tabview/ideview.coffee
@@ -419,6 +419,8 @@ class IDE.IDEView extends IDE.WorkspaceTabView
 
   createPlusContextMenu: ->
 
+    return  if @isReadOnly
+
     offset      = @holderView.plusHandle.$().offset()
     offsetLeft  = offset.left - 133
     margin      = if offsetLeft >= -1 then -20 else 12

--- a/views/tabview/ideview.coffee
+++ b/views/tabview/ideview.coffee
@@ -254,7 +254,7 @@ class IDE.IDEView extends IDE.WorkspaceTabView
       else
         appManager.tell 'IDE', 'hideFindAndReplaceView'
 
-    unless @suppressChangeHandlers
+    if not @suppressChangeHandlers and not @isReadOnly
       @emitChange pane, context: {}, 'TabChanged'
 
 

--- a/workspace/panes/drawingpane.coffee
+++ b/workspace/panes/drawingpane.coffee
@@ -12,6 +12,12 @@ class IDE.DrawingPane extends IDE.Pane
 
     super options, data
 
+    KD.singletons.appManager.tell 'IDE', 'setRealTimeManager', this
+
+    @once 'RealTimeManagerSet', =>
+      myPermission = @rtm.getFromModel('permissions').get KD.nick()
+      @makeReadOnly()  if myPermission is 'read'
+
 
   createCanvas: ->
 

--- a/workspace/panes/drawingpane.coffee
+++ b/workspace/panes/drawingpane.coffee
@@ -14,6 +14,7 @@ class IDE.DrawingPane extends IDE.Pane
 
 
   createCanvas: ->
+
     @canvas      = new KDCustomHTMLView
       tagName    : 'canvas'
       attributes :
@@ -24,6 +25,7 @@ class IDE.DrawingPane extends IDE.Pane
 
 
   createToolbar: ->
+
     @toolbar  = new KDCustomHTMLView cssClass: 'drawing-board-toolbar'
     commands  =
       undo    : action : 'undo'
@@ -55,6 +57,7 @@ class IDE.DrawingPane extends IDE.Pane
 
 
   showPenSizes: ->
+
     items = []
 
     penSizes.forEach (size) =>
@@ -67,6 +70,7 @@ class IDE.DrawingPane extends IDE.Pane
 
 
   showColors: ->
+
     items  = []
 
     colors.forEach (color) =>
@@ -79,6 +83,7 @@ class IDE.DrawingPane extends IDE.Pane
 
 
   createToolbarMenu: (items) ->
+
     @toolbarMenu?.destroy()
 
     @addSubView @toolbarMenu = new KDCustomHTMLView
@@ -90,6 +95,7 @@ class IDE.DrawingPane extends IDE.Pane
 
 
   init: ->
+
     @$canvas = @canvas.getDomElement()
     @$canvas.sketchpad
       aspectRatio : 1
@@ -103,6 +109,7 @@ class IDE.DrawingPane extends IDE.Pane
 
 
   emitChangeHappened: ->
+
     @emit 'ChangeHappened', {
       origin     : KD.nick()
       type       : 'DrawingBoardUpdated'
@@ -113,6 +120,7 @@ class IDE.DrawingPane extends IDE.Pane
     }
 
   addLayerForMenu: ->
+
     KD.getSingleton('windowController').addLayer @toolbarMenu
 
     @toolbarMenu.once 'ReceivedClickElsewhere', =>
@@ -122,6 +130,7 @@ class IDE.DrawingPane extends IDE.Pane
 
 
   handleColorChange: (color) ->
+
     @setPenColor color
     @colorMenuView.updatePartial "<p class='icon' style='background-color:#{color}'></p>"
     @colorMenuView.unsetClass 'selected'
@@ -129,17 +138,20 @@ class IDE.DrawingPane extends IDE.Pane
 
 
   handlePenSizeChange: (size) ->
+
     @setPenSize size
     @penSizeMenuView.unsetClass 'selected'
     @toolbarMenu.destroy()
 
 
   redo: ->
+
     @$canvas.redo()
     @emit 'DrawingBoardUpdated'
 
 
   undo: ->
+
     @$canvas.undo()
     @emit 'DrawingBoardUpdated'
 
@@ -163,16 +175,19 @@ class IDE.DrawingPane extends IDE.Pane
 
 
   clear: ->
+
     @$canvas.clear()
     @emit 'DrawingBoardUpdated'
 
 
   save: ->
+
     new KDNotificationView
       title: 'Saving will be enabled soon.'
 
 
   serialize: ->
+
     data       =
       data     : @getCanvasData()
       hash     : @hash
@@ -182,12 +197,14 @@ class IDE.DrawingPane extends IDE.Pane
 
 
   handleChange: (change) ->
+
     return unless change.context?.data
 
     @setCanvasData change.context.data
 
 
   viewAppended: ->
+
     super
 
     @createCanvas()

--- a/workspace/panes/drawingpane.coffee
+++ b/workspace/panes/drawingpane.coffee
@@ -174,6 +174,12 @@ class IDE.DrawingPane extends IDE.Pane
   setCanvasData: (json) -> @$canvas.jsonLoad json
 
 
+  makeEditable: -> @$canvas.setReadOnly no
+
+
+  makeReadOnly: -> @$canvas.setReadOnly yes
+
+
   clear: ->
 
     @$canvas.clear()

--- a/workspace/panes/editorpane.coffee
+++ b/workspace/panes/editorpane.coffee
@@ -53,6 +53,10 @@ class IDE.EditorPane extends IDE.Pane
 
       KD.singletons.appManager.tell 'IDE', 'setRealTimeManager', this
 
+      @once 'RealTimeManagerSet', =>
+        myPermission = @rtm.getFromModel('permissions').get KD.nick()
+        @makeReadOnly()  if myPermission is 'read'
+
 
   handleAutoSave: ->
 

--- a/workspace/panes/editorpane.coffee
+++ b/workspace/panes/editorpane.coffee
@@ -55,11 +55,13 @@ class IDE.EditorPane extends IDE.Pane
 
 
   handleAutoSave: ->
+
     return   if @getFile().path.indexOf('localfile:/') > -1
     @save()  if @getAce().isContentChanged()
 
 
   save: ->
+
     @getAce().emit 'ace.requests.save', @getContent()
 
 

--- a/workspace/panes/editorpane.coffee
+++ b/workspace/panes/editorpane.coffee
@@ -217,7 +217,7 @@ class IDE.EditorPane extends IDE.Pane
       @lineWidgets[username] = lineWidgetOptions
 
 
-  handleChange: (change, rtm, realTimeDoc) ->
+  handleChange: (change) ->
 
     {context, type, origin} = change
 

--- a/workspace/panes/editorpane.coffee
+++ b/workspace/panes/editorpane.coffee
@@ -323,9 +323,9 @@ class IDE.EditorPane extends IDE.Pane
 
   makeReadOnly: ->
 
-    @getEditor().setReadOnly yes
+    @getEditor()?.setReadOnly yes
 
 
   makeEditable: ->
 
-    @getEditor().setReadOnly no
+    @getEditor()?.setReadOnly no

--- a/workspace/panes/editorpane.coffee
+++ b/workspace/panes/editorpane.coffee
@@ -317,3 +317,13 @@ class IDE.EditorPane extends IDE.Pane
       @getEditorSession().remove range
 
     @dontEmitChangeEvent = no
+
+
+  makeReadOnly: ->
+
+    @getEditor().setReadOnly yes
+
+
+  makeEditable: ->
+
+    @getEditor().setReadOnly no

--- a/workspace/panes/finderpane.coffee
+++ b/workspace/panes/finderpane.coffee
@@ -19,7 +19,9 @@ class IDE.FinderPane extends IDE.Pane
       @addSubView fc.getView()
       @bindListeners()
 
+
   bindListeners: ->
+
     mgr = KD.getSingleton 'appManager'
     fc  = @finderController
 
@@ -31,6 +33,14 @@ class IDE.FinderPane extends IDE.Pane
     fc.treeController.on 'TerminalRequested', (machine) ->
       mgr.tell 'IDE', 'openMachineTerminal', machine
 
-    @on 'MachineMountRequested',   (machine, rootPath) -> fc.mountMachine machine, { mountPath: rootPath }
+    @on 'MachineMountRequested', (machine, rootPath) ->
+      fc.mountMachine machine, { mountPath: rootPath }
 
-    @on 'MachineUnmountRequested', (machine) -> fc.unmountMachine machine.uid
+    @on 'MachineUnmountRequested', (machine) ->
+      fc.unmountMachine machine.uid
+
+
+  makeReadOnly: -> @finderController.setReadOnly yes
+
+
+  makeEditable: -> @finderController.setReadOnly no

--- a/workspace/panes/finderpane.coffee
+++ b/workspace/panes/finderpane.coffee
@@ -34,6 +34,12 @@ class IDE.FinderPane extends IDE.Pane
     tc.on 'TerminalRequested', (machine) ->
       mgr.tell 'IDE', 'openMachineTerminal', machine
 
+    tc.on 'FolderCollapsed', (path) =>
+      @emit 'ChangeHappened', @getChangeObject 'Collapsed', path
+
+    tc.on 'FolderExpanded', (path) =>
+      @emit 'ChangeHappened', @getChangeObject 'Expanded', path
+
     @on 'MachineMountRequested', (machine, rootPath) ->
       fc.mountMachine machine, { mountPath: rootPath }
 
@@ -45,3 +51,15 @@ class IDE.FinderPane extends IDE.Pane
 
 
   makeEditable: -> @finderController.setReadOnly no
+
+
+  getChangeObject: (action, path) ->
+
+    change     =
+      origin   : KD.nick()
+      type     : 'FileTreeInteraction'
+      context  :
+        action : action
+        path   : path
+
+    return change

--- a/workspace/panes/finderpane.coffee
+++ b/workspace/panes/finderpane.coffee
@@ -63,3 +63,22 @@ class IDE.FinderPane extends IDE.Pane
         path   : path
 
     return change
+
+
+  handleChange: (change = {}) ->
+
+    return  unless change.type is 'FileTreeInteraction'
+
+    {context} = change
+    return  unless context
+
+    {action} = context
+    fc = @finderController
+    tc = fc.treeController
+
+    tc.dontEmitChangeEvent = yes
+
+    if      action is 'Expanded'  then fc.expandFolders context.path
+    else if action is 'Collapsed' then tc.collapseFolder tc.nodes[context.path]
+
+    tc.dontEmitChangeEvent = no

--- a/workspace/panes/finderpane.coffee
+++ b/workspace/panes/finderpane.coffee
@@ -24,13 +24,14 @@ class IDE.FinderPane extends IDE.Pane
 
     mgr = KD.getSingleton 'appManager'
     fc  = @finderController
+    tc  = @finderController.treeController
 
     fc.on 'FileNeedsToBeOpened', (file) ->
       file.fetchContents (err, contents) ->
         mgr.tell 'IDE', 'openFile', file, contents
         KD.getSingleton('windowController').setKeyView null
 
-    fc.treeController.on 'TerminalRequested', (machine) ->
+    tc.on 'TerminalRequested', (machine) ->
       mgr.tell 'IDE', 'openMachineTerminal', machine
 
     @on 'MachineMountRequested', (machine, rootPath) ->

--- a/workspace/panes/terminalpane.coffee
+++ b/workspace/panes/terminalpane.coffee
@@ -14,6 +14,7 @@ class IDE.TerminalPane extends IDE.Pane
 
 
   createTerminal: ->
+
     options =
       delegate         : this
       readOnly         : @getOption 'readOnly'
@@ -58,10 +59,12 @@ class IDE.TerminalPane extends IDE.Pane
 
 
   getMode: ->
+
     return  if @session? then 'resume' else 'create'
 
 
   runCommand: (command, callback) ->
+
     return unless command
 
     unless @remote
@@ -75,16 +78,19 @@ class IDE.TerminalPane extends IDE.Pane
 
 
   resurrect: ->
+
     @destroySubViews()
     @createTerminal()
 
 
   setFocus: (state) ->
+
     super state
     @webtermView.setFocus state
 
 
   serialize: ->
+
     {label, ipAddress, slug, uid} = @machine
     {path, paneType} = @getOptions()
 

--- a/workspace/panes/terminalpane.coffee
+++ b/workspace/panes/terminalpane.coffee
@@ -60,6 +60,7 @@ class IDE.TerminalPane extends IDE.Pane
   getMode: ->
     return  if @session? then 'resume' else 'create'
 
+
   runCommand: (command, callback) ->
     return unless command
 
@@ -72,11 +73,11 @@ class IDE.TerminalPane extends IDE.Pane
 
     @remote.input "#{command}\n"
 
-  notify: (message) -> console.log 'notify:', message
 
   resurrect: ->
     @destroySubViews()
     @createTerminal()
+
 
   setFocus: (state) ->
     super state

--- a/workspace/panes/terminalpane.coffee
+++ b/workspace/panes/terminalpane.coffee
@@ -57,6 +57,12 @@ class IDE.TerminalPane extends IDE.Pane
 
       @machine.getBaseKite().fetchTerminalSessions()
 
+    KD.singletons.appManager.tell 'IDE', 'setRealTimeManager', this
+
+    @once 'RealTimeManagerSet', =>
+      myPermission = @rtm.getFromModel('permissions').get KD.nick()
+      @makeReadOnly()  if myPermission is 'read'
+
 
   getMode: ->
 

--- a/workspace/panes/terminalpane.coffee
+++ b/workspace/panes/terminalpane.coffee
@@ -100,3 +100,26 @@ class IDE.TerminalPane extends IDE.Pane
       paneType : paneType
       session  : @remote?.session
       hash     : @hash
+
+
+  setEditMode: (state) ->
+
+    {terminal} = @webtermView
+    return  unless terminal
+
+    {cursor} = terminal
+    return  unless cursor
+
+    if state
+      @webtermView.terminal.isReadOnly = no
+      cursor.stopped = no
+      cursor.setBlinking yes
+    else
+      @webtermView.terminal.isReadOnly = yes
+      cursor.stopBlink()
+
+
+  makeEditable: -> @setEditMode yes
+
+
+  makeReadOnly: -> @setEditMode no


### PR DESCRIPTION
- [x] Implement makeReadOnly/makeEditable interface for editor.
- [x] Implement makeReadOnly/makeEditable interface for terminal.
- [x] Implement makeReadOnly/makeEditable interface for drawing board.
- [x] Implement makeReadOnly/makeEditable interface for file tree.
- [x] Add a method to AppController to switch between readonly and editable mode.
- [x] Disable syncing tab change when readonly.
- [x] Disable tab closing when readonly.
- [x] Hide `+` handle in IDEViews and disable click handler.
- [x] Write file tree interactions to Realtime document.
- [x] Sync host file tree interactions like folder open/close to participants.
- [x] Enable chat settings pane.
- [x] Show default permission state correctly.
- [x] Make permission settings select boxes disabled for participants.
- [x] Write participants initial permission state to RealTimeDocument.
- [x] Update participant permission state after host change.
- [x] Show participant permission state in settings pane correctly.
- [x] Set new joined user's permission by looking default permission on settings pane.
- [x] Apply new permission for that participant for all open IDE panes.
- [x] Apply current permission for newly created IDE panes.
- [x] Apply user permission after page refreshed.