### PR TITLE
Filetree: fix problem with menu button after resize

### DIFF
--- a/styl/ide.finder.styl
+++ b/styl/ide.finder.styl
@@ -321,6 +321,9 @@ body.ide
         color             #949290
         font-size         13px
         margin-left       15px
+        margin-right      40px
+        display           block
+        position          initial
         top               0
         left              0
         opacity           1

--- a/styl/ide.finder.styl
+++ b/styl/ide.finder.styl
@@ -17,7 +17,7 @@ body.ide
   .nfinder
     styleScrollBars rgba(255,255,255,.25)
     > .kdscrollview > *
-      min-width         234px
+      min-width         70px
 
     ul ul li.selected
       bg                color, #131313


### PR DESCRIPTION
now for small area it looks like this:
![untitled](https://cloud.githubusercontent.com/assets/295206/5718992/91a54312-9b24-11e4-8adb-0912a599f419.png)

@sinan plz review this
