### PR TITLE
Router: Improvements and fixes

### DIFF
--- a/routes.coffee
+++ b/routes.coffee
@@ -16,9 +16,18 @@ do ->
 
     kallback = (workspaces) ->
 
-      for machine in KD.userMachines \
-        when (machine.slug or machine.label) is machineLabel
+      username ?= KD.nick()
+
+      for machine in KD.userMachines
+        unless machine instanceof Machine
+          machine = new Machine machine: KD.remote.revive machine
+
+        sameLabel = (machine.slug or machine.label) is machineLabel
+        sameOwner = machine.getOwner() is username
+
+        if sameLabel and sameOwner
           machineUId = machine.uid
+          break
 
       for workspace in workspaces
         continue  unless workspace.machineUId is machineUId
@@ -61,8 +70,11 @@ do ->
 
     for m in KD.userMachines
 
-      sameLabel = (m.label is label) or (m.slug is label)
+      unless m instanceof Machine
+        m = new Machine machine: KD.remote.revive m
+
       sameUser  = m.getOwner() is username
+      sameLabel = (m.label or m.slug) is label
 
       return m  if sameLabel and sameUser
 

--- a/routes.coffee
+++ b/routes.coffee
@@ -2,6 +2,7 @@ do ->
 
   loadWorkspace = ({machineLabel, username}, workspace) ->
 
+    username or= KD.nick()
     machine = getMachine machineLabel, username
     loadIDE { machine, workspace, username }
 
@@ -200,11 +201,11 @@ do ->
 
       {machineLabel} = params
 
+      params.username = KD.nick()
+
       refreshWorkspaces ->
 
         findWorkspace params, (workspace) ->
-
-          params.username = KD.nick()
 
           if workspace
             return loadWorkspace params, workspace

--- a/routes.coffee
+++ b/routes.coffee
@@ -149,6 +149,17 @@ do ->
       KD.getSingleton('router').handleRoute "/IDE/#{machineLabel}/#{workspaceSlug}"
 
 
+  routeToMachineWorkspace = (machine) ->
+
+    if {machineLabel} = latestWorkspace = getLatestWorkspace()
+      if machineLabel is machine.label
+        workspaceSlug = latestWorkspace.workspaceSlug
+
+    workspaceSlug ?= 'my-workspace'
+
+    KD.getSingleton('router').handleRoute "/IDE/#{machine.label}/#{workspaceSlug}"
+
+
   routeToLatestWorkspace = ->
 
     router = KD.getSingleton 'router'

--- a/routes.coffee
+++ b/routes.coffee
@@ -54,17 +54,13 @@ do ->
 
 
   getMachine = (label, username) ->
-    machine = null
 
     for m in KD.userMachines
 
-      hasSameLabel = (m.label is label) or (m.slug is label)
-      hasSameUser  = m.getOwner() is username
+      sameLabel = (m.label is label) or (m.slug is label)
+      sameUser  = m.getOwner() is username
 
-      if hasSameLabel and hasSameUser
-        machine = m
-
-    return machine
+      return m  if sameLabel and sameUser
 
 
   loadIDE = (data) ->

--- a/routes.coffee
+++ b/routes.coffee
@@ -1,9 +1,12 @@
 do ->
 
-  loadWorkspace = ({machineLabel, username}, workspace) ->
+  loadWorkspace = (workspace, options) ->
+
+    {machine, machineLabel, username} = options
 
     username or= KD.nick()
-    machine = getMachine machineLabel, username
+    machine  or= getMachine machineLabel, username
+
     loadIDE { machine, workspace, username }
 
 
@@ -208,13 +211,13 @@ do ->
         findWorkspace params, (workspace) ->
 
           if workspace
-            return loadWorkspace params, workspace
+            return loadWorkspace workspace, params
           else
             for machine in KD.userMachines when machine.label is machineLabel
               break
 
             if machine
             then putVMInWorkspace machine
-            else loadWorkspace params
+            else loadWorkspace null, params
 
           routeToLatestWorkspace()

--- a/routes.coffee
+++ b/routes.coffee
@@ -151,26 +151,19 @@ do ->
 
         KD.userWorkspaces.forEach (workspace, index) =>
 
-          if workspace.channelId is channel.id
+          return  if workspace.channelId isnt channel.id
 
-            machine = (KD.userMachines.filter (m) -> m.uid is workspace.machineUId)[0]
-            query   = socialApiId: channel.creatorId
+          machine = (KD.userMachines.filter (m) -> m.uid is workspace.machineUId)[0]
+          query   = socialApiId: channel.creatorId
 
-            KD.remote.api.JAccount.some query, {}, (err, account) =>
+          KD.remote.api.JAccount.some query, {}, (err, account) =>
 
-              return throw new Error err  if err
+            return throw new Error err  if err
 
-              username  = account.first.profile.nickname
-              channelId = channel.id
+            username  = account.first.profile.nickname
+            channelId = channel.id
 
-              return loadIDE { machine, workspace, username, channelId }
-
-          # Commented out because of the side effects. ~Umut
-          # (e.g can't select random vms/workspaces)
-
-          # else
-          #   if index + 1 is KD.userWorkspaces.length
-          #     routeToLatestWorkspace()
+            return loadIDE { machine, workspace, username, channelId }
 
       catch e
 

--- a/routes.coffee
+++ b/routes.coffee
@@ -1,26 +1,9 @@
 do ->
 
-  loadWorkspace = (options, workspace) ->
-
-    {machineLabel, workspaceSlug, username} = options
+  loadWorkspace = ({machineLabel, username}, workspace) ->
 
     machine = getMachine machineLabel, username
-
-    if workspace
-      loadIDE { machine, workspace, username }
-
-    else if workspaceSlug is 'my-workspace'
-      workspace = new KD.remote.api.JWorkspace
-        _id          : 'my-workspace'
-        isDummy      : yes
-        isDefault    : yes
-        slug         : 'my-workspace'
-        machineLabel : machine?.slug or machine?.label
-
-      loadIDE { machine, workspace, username }
-
-    else
-      routeToLatestWorkspace()
+    loadIDE { machine, workspace, username }
 
 
   findWorkspace = (options, callback) ->

--- a/routes.coffee
+++ b/routes.coffee
@@ -67,6 +67,12 @@ do ->
       return m  if sameLabel and sameUser
 
 
+  getLatestWorkspace = ->
+
+    storage = KD.getSingleton('localStorageController').storage 'IDE'
+    return storage.getValue 'LatestWorkspace'
+
+
   loadIDE = (data) ->
 
     { machine, workspace, username, channelId } = data

--- a/routes.coffee
+++ b/routes.coffee
@@ -57,7 +57,7 @@ do ->
     mainView.activitySidebar.selectWorkspace data
 
 
-  getMachine = (label, username) ->
+  getMachine = (label, username = KD.nick()) ->
 
     for m in KD.userMachines
 

--- a/routes.coffee
+++ b/routes.coffee
@@ -129,26 +129,6 @@ do ->
       else routeToMachineWorkspace machines.first
 
 
-  putVMInWorkspace = (machine) ->
-
-    localStorage    = KD.getSingleton("localStorageController").storage "IDE"
-    latestWorkspace = localStorage.getValue 'LatestWorkspace'
-
-    machineLabel    = machine.slug or machine.label
-    workspaceSlug   = 'my-workspace'
-    username        = machine.getOwner()
-
-    if latestWorkspace and latestWorkspace.machineLabel is machineLabel
-      for ws in KD.userWorkspaces when ws.slug is latestWorkspace.workspaceSlug
-        {workspaceSlug} = latestWorkspace
-
-    if workspaceSlug is 'my-workspace'
-      loadWorkspace {machineLabel, workspaceSlug, username}
-
-    KD.utils.defer ->
-      KD.getSingleton('router').handleRoute "/IDE/#{machineLabel}/#{workspaceSlug}"
-
-
   routeToMachineWorkspace = (machine) ->
 
     if {machineLabel} = latestWorkspace = getLatestWorkspace()
@@ -237,7 +217,7 @@ do ->
       if /^[0-9]+$/.test machineLabel
         refreshWorkspaces -> loadCollaborativeIDE machineLabel
       else if machine = getMachine machineLabel
-        putVMInWorkspace machine
+        routeToMachineWorkspace machine
       else
         routeToLatestWorkspace()
 
@@ -258,7 +238,7 @@ do ->
               break
 
             if machine
-            then putVMInWorkspace machine
+            then routeToMachineWorkspace machine
             else loadWorkspace null, params
 
           routeToLatestWorkspace()

--- a/routes.coffee
+++ b/routes.coffee
@@ -109,6 +109,20 @@ do ->
       callback()
 
 
+  routeToFallback = ->
+
+    router = KD.getSingleton 'router'
+
+    for machine in KD.userMachines when machine.isMine()
+      return routeToMachineWorkspace machine
+
+    KD.singletons.computeController.fetchMachines (err, machines) ->
+
+      if err or not machines.length
+      then router.handleRoute "/IDE/koding-vm-0/my-workspace"
+      else routeToMachineWorkspace machines.first
+
+
   putVMInWorkspace = (machine) ->
 
     localStorage    = KD.getSingleton("localStorageController").storage "IDE"


### PR DESCRIPTION
Test cases:

- [x] /IDE

Route to most recently opened workspace and still available workspace. If machine and/or workspace is missing route to fallback.

- [x] /IDE/machine-label

Route to `my-workspace` of specified machine if it exists. Otherwise route to most recently opened workspace like `/IDE` route handler.

- [x] /IDE/machine-label/workspace-slug

Load specified workspace if machine and workspace is available.

- [x] /IDE/machine-label/non-existent-workspace-slug

Route to `my-workspace` of specified machine.

- [x] /IDE/non-existent-machine-label
- [x] /IDE/non-existent-machine-label/non-existent-workspace-slug

Route to fallback

- [x] /IDE/not-initialized-machine-label
- [x] /IDE/not-initialized-machine-label/non-existent-workspace-slug

Show state modal to start building machine.

- [x] /IDE/channel-id

Load shared workspace into IDE. If it is not available then route to most recently opened workspace.

- [x] Reload browser window on each route
- [x] Logout on each route and login back
- [x] Clear local storage entry `LatestWorkspace` before testing

Router should behave as specified in each case.
