### PR TITLE
ide: resolved bug(Filetree was displayed twice)

### DIFF
--- a/AppController.coffee
+++ b/AppController.coffee
@@ -243,6 +243,9 @@ class IDEAppController extends AppController
 
   mountMachine: (machineData) ->
 
+    # interrupt if workspace was changed
+    return if machineData.uid isnt @workspaceData.machineUId
+    
     panel        = @workspace.getView()
     filesPane    = panel.getPaneByName 'filesPane'
 


### PR DESCRIPTION
@sinan @fatihacet @usirin plz review. 
now we don't mount machine if it's not active.