### PR TITLE
ide: update statusBar when terminal is focused

### DIFF
--- a/views/tabview/ideview.coffee
+++ b/views/tabview/ideview.coffee
@@ -268,6 +268,8 @@ class IDE.IDEView extends IDE.WorkspaceTabView
 
     appManager.tell 'IDE', 'setActiveTabView', @tabView
     appManager.tell 'IDE', 'setFindAndReplaceViewDelegate'
+    
+    @updateStatusBar()
 
 
   openSavedFile: (file, content) ->


### PR DESCRIPTION
When Terminal gets focus, the status bar shows Terminal details instead of previous value.